### PR TITLE
Prefer admin defined DNS

### DIFF
--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -199,7 +199,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             raise CoreDNSError() from None
 
     async def reset(self) -> None:
-        """Reset DNS and hosts"""
+        """Reset DNS and hosts."""
         # Reset manually defined DNS
         self.servers.clear()
         self.save_data()

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -215,12 +215,12 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             _LOGGER.error("Can't read coredns template file: %s", err)
             raise CoreDNSError() from None
 
-        # Prepare DNS serverlist: Prio 1 Local, Prio 2 Manual, Prio 3 Fallback
+        # Prepare DNS serverlist: Prio 1 Manual, Prio 2 Local, Prio 3 Fallback
         local_dns: List[str] = self.sys_host.network.dns_servers or ["dns://127.0.0.11"]
         _LOGGER.debug(
-            "local-dns = %s, config-dns = %s, backup-dns = %s",
-            local_dns,
+            "config-dns = %s, local-dns = %s , backup-dns = %s",
             self.servers,
+            local_dns,
             DNS_SERVERS,
         )
         for server in self.servers + local_dns + DNS_SERVERS:

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -195,7 +195,10 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
 
     async def reset(self) -> None:
         """Reset Config / Hosts."""
+        # TODO: After v200 reset will remove manually defined DNS, rather than setting to fallback
+        _LOGGER.info("In v200 this will remove any manually defined servers, for now we set them to %s", DNS_SERVERS)
         self.servers = DNS_SERVERS
+        # self.servers = []
 
         # Resets hosts
         with suppress(OSError):

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -223,18 +223,8 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             raise CoreDNSError() from None
 
         # Prepare DNS serverlist: Prio 1 Manual, Prio 2 Local, Prio 3 Fallback
-        # If Manual servers are identical to Fallback (was default before 194), then ignore manual
         local_dns: List[str] = self.sys_host.network.dns_servers or ["dns://127.0.0.11"]
-        if DNS_SERVERS == self.servers:
-            _LOGGER.debug(
-                "Manually defined DNS servers are identical to fallback. Ignoring manually defined DNS."
-            )
-            servers: List[str] = local_dns + DNS_SERVERS
-        else:
-            _LOGGER.debug(
-                "Manually defined DNS servers are set. Preferring manually defined DNS."
-            )
-            servers: List[str] = self.servers + local_dns + DNS_SERVERS
+        servers: List[str] = self.servers + local_dns + DNS_SERVERS
 
         _LOGGER.debug(
             "config-dns = %s, local-dns = %s , backup-dns = %s",

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -196,7 +196,10 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
     async def reset(self) -> None:
         """Reset Config / Hosts."""
         # After v200 reset will remove manually defined DNS, rather than setting to fallback
-        _LOGGER.info("In v200 this will remove any manually defined servers, for now we set them to %s", DNS_SERVERS)
+        _LOGGER.info(
+            "In v200 this will remove any manually defined servers, for now we set them to %s",
+            DNS_SERVERS,
+        )
         self.servers = DNS_SERVERS
         # self.servers = []
 

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -195,7 +195,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
 
     async def reset(self) -> None:
         """Reset Config / Hosts."""
-        # TODO: After v200 reset will remove manually defined DNS, rather than setting to fallback
+        # After v200 reset will remove manually defined DNS, rather than setting to fallback
         _LOGGER.info("In v200 this will remove any manually defined servers, for now we set them to %s", DNS_SERVERS)
         self.servers = DNS_SERVERS
         # self.servers = []

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -223,7 +223,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             self.servers,
             DNS_SERVERS,
         )
-        for server in self.servers + local_dns  + DNS_SERVERS:
+        for server in self.servers + local_dns + DNS_SERVERS:
             try:
                 dns_url(server)
                 if server not in dns_servers:

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -223,7 +223,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             self.servers,
             DNS_SERVERS,
         )
-        for server in local_dns + self.servers + DNS_SERVERS:
+        for server in self.servers + local_dns  + DNS_SERVERS:
             try:
                 dns_url(server)
                 if server not in dns_servers:

--- a/hassio/dns.py
+++ b/hassio/dns.py
@@ -199,6 +199,7 @@ class CoreDNS(JsonConfig, CoreSysAttributes):
             raise CoreDNSError() from None
 
     async def reset(self) -> None:
+        """Reset DNS and hosts"""
         # Reset manually defined DNS
         self.servers.clear()
         self.save_data()


### PR DESCRIPTION
Small change to prefer admin defined DNS servers, that is those defined using ```hassio dns options --servers dns://1.2.3.4``` 

See #1316 for discussion.
