### PR TITLE
Service data is optional, does not have to exists yet

### DIFF
--- a/hassio/services/data.py
+++ b/hassio/services/data.py
@@ -1,5 +1,5 @@
 """Handle service data for persistent supervisor reboot."""
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from ..const import FILE_HASSIO_SERVICES
 from ..utils.json import JsonConfig
@@ -15,11 +15,11 @@ class ServicesData(JsonConfig):
         super().__init__(FILE_HASSIO_SERVICES, SCHEMA_SERVICES_CONFIG)
 
     @property
-    def mqtt(self) -> Dict[str, Any]:
+    def mqtt(self) -> Optional[Dict[str, Any]]:
         """Return settings for MQTT service."""
-        return self._data[SERVICE_MQTT]
+        return self._data.get(SERVICE_MQTT)
 
     @property
-    def mysql(self) -> Dict[str, Any]:
+    def mysql(self) -> Optional[Dict[str, Any]]:
         """Return settings for MySQL service."""
-        return self._data[SERVICE_MYSQL]
+        return self._data.get(SERVICE_MYSQL)


### PR DESCRIPTION
The service interface check if the service is enabled by checking if the service contains data. However, in case of a new service (like the added MySQL), the data doesn't have to be in the data file yet.

```
20-01-26 21:42:51 INFO (SyncWorker_0) [hassio.docker.addon] Start Docker add-on local/amd64-addon-mariadb with version 1.3
20-01-26 21:42:53 ERROR (MainThread) [aiohttp.server] Error handling request
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_protocol.py", line 418, in start
    resp = await task
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_app.py", line 458, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.7/site-packages/aiohttp/web_middlewares.py", line 119, in impl
    return await handler(request)
  File "/usr/src/hassio/hassio/api/security.py", line 147, in token_validation
    return await handler(request)
  File "/usr/src/hassio/hassio/api/utils.py", line 39, in wrap_api
    answer = await method(api, *args, **kwargs)
  File "/usr/src/hassio/hassio/api/services.py", line 50, in set_service
    service.set_service_data(addon, body)
  File "/usr/src/hassio/hassio/services/modules/mysql.py", line 58, in set_service_data
    if self.enabled:
  File "/usr/src/hassio/hassio/services/interface.py", line 45, in enabled
    return bool(self._data)
  File "/usr/src/hassio/hassio/services/modules/mysql.py", line 49, in _data
    return self.sys_services.data.mysql
  File "/usr/src/hassio/hassio/services/data.py", line 25, in mysql
    return self._data[SERVICE_MYSQL]
KeyError: 'mysql'
```

This PR addresses this issue, by making the service data optional, and allow it to be None. For the interface, it should handle this correctly, since it casts this response to a boolean value.